### PR TITLE
Disable Sentry performance monitoring

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -6,11 +6,4 @@ import * as Sentry from '@sentry/nextjs'
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
-  // TODO add release, environment
-  // ...
-  // Note: if you want to override the automatic release value, do not set a
-  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
-  // that it will also get attached to your source maps
 })

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,11 +6,4 @@ import * as Sentry from '@sentry/nextjs'
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN_SERVER,
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
-  // TODO add release, environment
-  // ...
-  // Note: if you want to override the automatic release value, do not set a
-  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
-  // that it will also get attached to your source maps
 })


### PR DESCRIPTION
So we don't get notified about "transactions limit exceeded". This may possibly also speed up our app a little since Sentry won't be monitoring as much. **The changes should have no impact on Sentry error reporting.**

We don't have to merge into main ASAP, it can wait.