### PR TITLE
Add markdown support to lecture and post comments

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .next
+public/__

--- a/next.config.js
+++ b/next.config.js
@@ -21,13 +21,11 @@ const nextConfig = {
     return [
       {
         source: '/__/auth/handler',
-        destination:
-          '/__/auth/handler.html',
+        destination: '/__/auth/handler.html',
       },
       {
         source: '/__/auth/iframe',
-        destination:
-          '/__/auth/iframe.html',
+        destination: '/__/auth/iframe.html',
       },
     ]
   },

--- a/src/components/Head.tsx
+++ b/src/components/Head.tsx
@@ -36,7 +36,10 @@ const Head = ({
       <meta property="og:image" content={imageUrl || DEFAULT_LOGO_IMAGE_URL} />
       <meta property="og:image:alt" content={imageAlt || title} />
 
-      <meta name="google-site-verification" content="FB24EUCOSSYhz39LdPTSNW4Yebc0El71AV7luRQcQQc" />
+      <meta
+        name="google-site-verification"
+        content="FB24EUCOSSYhz39LdPTSNW4Yebc0El71AV7luRQcQQc"
+      />
       {noIndex && <meta name="robots" content="noindex" />}
     </_NextHead>
   )

--- a/src/components/core/MarkdownView.tsx
+++ b/src/components/core/MarkdownView.tsx
@@ -86,7 +86,6 @@ const StyledMarkdown = styled(ReactMarkdown)`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  overflow: auto;
 
   ul {
     margin: 0;

--- a/src/components/core/TextField.tsx
+++ b/src/components/core/TextField.tsx
@@ -13,6 +13,7 @@ type Props = {
   disabled?: boolean
   borderColor?: Color
   inputBackgroundColor?: Color
+  maxRows?: number
 } & HTMLAttributes<HTMLElement>
 
 type Color = 'primary' | 'secondary' | 'accent'
@@ -28,6 +29,7 @@ const TextField = ({
   disabled,
   borderColor,
   inputBackgroundColor,
+  maxRows,
   ...props
 }: Props) => {
   const inputRef = useRef<HTMLDivElement>()
@@ -49,7 +51,7 @@ const TextField = ({
         onChange={onTextChanged}
         multiline
         minRows={1}
-        maxRows={6}
+        maxRows={maxRows || 6}
         fullWidth
         disabled={disabled}
         inputProps={{

--- a/src/components/domain/lecture-comment/EditableLectureComment.tsx
+++ b/src/components/domain/lecture-comment/EditableLectureComment.tsx
@@ -1,12 +1,12 @@
 import React, {ChangeEvent, useState} from 'react'
-import {AiOutlineEdit} from 'react-icons/ai'
-import {MdOutlinePreview} from 'react-icons/md'
 import styled, {css} from 'styled-components'
 import Button from '../../core/Button'
 import Flex from '../../core/Flex'
 import MarkdownView from '../../core/MarkdownView'
 import TextField from '../../core/TextField'
 import Loading from '../../Loading'
+import {BiToggleLeft, BiToggleRight} from 'react-icons/bi'
+import Text from '../../core/Text'
 
 type EditableLectureCommentProps = {
   /* Props for existing lecture comment */
@@ -34,6 +34,7 @@ const EditableLectureComment = ({
     await onSubmit(text).then(() => {
       setIsLoading(false)
       setText('')
+      setIsInPreview(false)
     })
   }
 
@@ -41,41 +42,34 @@ const EditableLectureComment = ({
     setIsInPreview(!isInPreview)
   }
 
-  const containsMarkdown =
-    text.includes('`') ||
-    text.includes('#') ||
-    text.includes('[') ||
-    text.includes(']') ||
-    text.includes(`'`)
+  const MarkdownPreview = () => {
+    return (
+      <MarkdownPreviewFlex justifyContent="flex-end">
+        <PreviewWrapper gap="8px" alignItems="center" onClick={togglePreview}>
+          <Text size="small" color="accent">
+            Markdown preview
+          </Text>
+          {isInPreview ? <StyledToggleRightIcon /> : <StyledToggleLeftIcon />}
+        </PreviewWrapper>
+      </MarkdownPreviewFlex>
+    )
+  }
 
   return (
     <WrapperFlex direction="column" alignItems="flex-start" alignSelf="stretch">
       {!isInPreview && (
         <TextField
-          itemBefore={
-            containsMarkdown && (
-              <PreviewIconFlex justifyContent="flex-end">
-                <StyledPreviewIcon
-                  onClick={() => togglePreview()}
-                  title="Zobraziť preview"
-                />
-              </PreviewIconFlex>
-            )
-          }
+          itemBefore={text.length > 0 && <MarkdownPreview />}
           text={text}
           onTextChanged={onTextChanged}
           maxLength={750}
+          maxRows={100}
           label="Sem napíš svoj komentár"
         />
       )}
       {isInPreview && (
         <CommentField>
-          <PreviewIconFlex justifyContent="flex-end">
-            <StyledEditIcon
-              onClick={() => togglePreview()}
-              title="Naspäť na editovanie"
-            />
-          </PreviewIconFlex>
+          <MarkdownPreview />
           <MarkdownView children={text} />
         </CommentField>
       )}
@@ -112,25 +106,32 @@ const CommentField = styled.div`
   border: 1px solid var(--color-accent);
 `
 
-const PreviewIconFlex = styled(Flex)`
+const MarkdownPreviewFlex = styled(Flex)`
+  padding-right: 12px;
   width: 100%;
+`
+
+const PreviewWrapper = styled(Flex)`
+  &:hover {
+    cursor: pointer;
+  }
 `
 
 const IconStyle = css`
   color: var(--color-accent);
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
 
   &:hover {
     cursor: pointer;
   }
 `
 
-const StyledPreviewIcon = styled(MdOutlinePreview)`
+const StyledToggleLeftIcon = styled(BiToggleLeft)`
   ${IconStyle}
 `
 
-const StyledEditIcon = styled(AiOutlineEdit)`
+const StyledToggleRightIcon = styled(BiToggleRight)`
   ${IconStyle}
 `
 

--- a/src/components/domain/lecture-comment/EditableLectureComment.tsx
+++ b/src/components/domain/lecture-comment/EditableLectureComment.tsx
@@ -1,7 +1,10 @@
 import React, {ChangeEvent, useState} from 'react'
-import styled from 'styled-components'
+import {AiOutlineEdit} from 'react-icons/ai'
+import {MdOutlinePreview} from 'react-icons/md'
+import styled, {css} from 'styled-components'
 import Button from '../../core/Button'
 import Flex from '../../core/Flex'
+import MarkdownView from '../../core/MarkdownView'
 import TextField from '../../core/TextField'
 import Loading from '../../Loading'
 
@@ -19,6 +22,7 @@ const EditableLectureComment = ({
   onSubmit,
 }: EditableLectureCommentProps) => {
   const [text, setText] = useState<string>(initialText || '')
+  const [isInPreview, setIsInPreview] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
   const onTextChanged = (e: ChangeEvent<HTMLInputElement>) => {
@@ -33,14 +37,48 @@ const EditableLectureComment = ({
     })
   }
 
+  const togglePreview = (): void => {
+    setIsInPreview(!isInPreview)
+  }
+
+  const containsMarkdown =
+    text.includes('`') ||
+    text.includes('#') ||
+    text.includes('[') ||
+    text.includes(']') ||
+    text.includes(`'`)
+
   return (
     <WrapperFlex direction="column" alignItems="flex-start" alignSelf="stretch">
-      <TextField
-        text={text}
-        onTextChanged={onTextChanged}
-        maxLength={750}
-        label="Sem napíš svoj komentár"
-      />
+      {!isInPreview && (
+        <TextField
+          itemBefore={
+            containsMarkdown && (
+              <PreviewIconFlex justifyContent="flex-end">
+                <StyledPreviewIcon
+                  onClick={() => togglePreview()}
+                  title="Zobraziť preview"
+                />
+              </PreviewIconFlex>
+            )
+          }
+          text={text}
+          onTextChanged={onTextChanged}
+          maxLength={750}
+          label="Sem napíš svoj komentár"
+        />
+      )}
+      {isInPreview && (
+        <CommentField>
+          <PreviewIconFlex justifyContent="flex-end">
+            <StyledEditIcon
+              onClick={() => togglePreview()}
+              title="Naspäť na editovanie"
+            />
+          </PreviewIconFlex>
+          <MarkdownView children={text} />
+        </CommentField>
+      )}
       {isLoading && <Loading />}
       {!isLoading && (
         <Flex alignItems="flex-end" gap="12px" alignSelf="flex-start">
@@ -65,6 +103,35 @@ const WrapperFlex = styled(Flex)`
 
 const SubmitButton = styled(Button)`
   margin-top: 12px;
+`
+
+const CommentField = styled.div`
+  width: 100%;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--color-accent);
+`
+
+const PreviewIconFlex = styled(Flex)`
+  width: 100%;
+`
+
+const IconStyle = css`
+  color: var(--color-accent);
+  width: 20px;
+  height: 20px;
+
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+const StyledPreviewIcon = styled(MdOutlinePreview)`
+  ${IconStyle}
+`
+
+const StyledEditIcon = styled(AiOutlineEdit)`
+  ${IconStyle}
 `
 
 export default EditableLectureComment

--- a/src/components/domain/lecture-comment/LectureCommentItem.tsx
+++ b/src/components/domain/lecture-comment/LectureCommentItem.tsx
@@ -6,6 +6,7 @@ import {LectureComment} from '../../../types'
 import {formatDate, formatDateTime} from '../../../utils'
 import {useDeleteLectureComment} from '../../../api/lectureComments'
 import Flex from '../../core/Flex'
+import MarkdownView from '../../core/MarkdownView'
 import Text from '../../core/Text'
 import Loading from '../../Loading'
 import UserAvatar from '../user/UserAvatar'
@@ -76,7 +77,7 @@ const LectureCommentItem = ({lectureId, comment}: LectureCommentItemProps) => {
                 </CommentTimeWrapper>
                 <Text size="very-small">{comment.userName}</Text>
               </Flex>
-              <StyledCommentText>{comment.commentText}</StyledCommentText>
+              <MarkdownView children={comment.commentText} />
             </Flex>
           </CommentField>
         )}
@@ -112,9 +113,6 @@ const CommentTimeWrapper = styled(Flex)`
     flex-direction: column;
     gap: 2px;
   }
-`
-const StyledCommentText = styled(Text)`
-  overflow-wrap: anywhere;
 `
 
 export default LectureCommentItem

--- a/src/components/domain/post-comment/EditablePostComment.tsx
+++ b/src/components/domain/post-comment/EditablePostComment.tsx
@@ -1,6 +1,4 @@
 import React, {ChangeEvent, useState} from 'react'
-import {AiOutlineEdit} from 'react-icons/ai'
-import {MdOutlinePreview} from 'react-icons/md'
 import styled, {css} from 'styled-components'
 import {useAuth} from '../../../AuthUserContext'
 import Button from '../../core/Button'
@@ -9,6 +7,7 @@ import MarkdownView from '../../core/MarkdownView'
 import Text from '../../core/Text'
 import TextField from '../../core/TextField'
 import Loading from '../../Loading'
+import {BiToggleLeft, BiToggleRight} from 'react-icons/bi'
 
 type EditablePostCommentProps = {
   /* Props for existing post comment */
@@ -37,6 +36,7 @@ const EditablePostComment = ({
     await onSubmit(text).then(() => {
       setIsLoading(false)
       setText('')
+      setIsInPreview(false)
     })
   }
 
@@ -44,41 +44,34 @@ const EditablePostComment = ({
     setIsInPreview(!isInPreview)
   }
 
-  const containsMarkdown =
-    text.includes('`') ||
-    text.includes('#') ||
-    text.includes('[') ||
-    text.includes(']') ||
-    text.includes(`'`)
+  const MarkdownPreview = () => {
+    return (
+      <MarkdownPreviewFlex justifyContent="flex-end">
+        <PreviewWrapper gap="8px" alignItems="center" onClick={togglePreview}>
+          <Text size="small" color="accent">
+            Markdown preview
+          </Text>
+          {isInPreview ? <StyledToggleRightIcon /> : <StyledToggleLeftIcon />}
+        </PreviewWrapper>
+      </MarkdownPreviewFlex>
+    )
+  }
 
   return (
     <WrapperFlex direction="column" alignItems="flex-start" alignSelf="stretch">
       {!isInPreview && (
         <TextField
-          itemBefore={
-            containsMarkdown && (
-              <PreviewIconFlex justifyContent="flex-end">
-                <StyledPreviewIcon
-                  onClick={() => togglePreview()}
-                  title="Zobraziť preview"
-                />
-              </PreviewIconFlex>
-            )
-          }
+          itemBefore={text.length > 0 && <MarkdownPreview />}
           text={text}
           onTextChanged={onTextChanged}
           maxLength={750}
+          maxRows={100}
           label="Sem napíš svoj komentár"
         />
       )}
       {isInPreview && (
         <CommentField>
-          <PreviewIconFlex justifyContent="flex-end">
-            <StyledEditIcon
-              onClick={() => togglePreview()}
-              title="Naspäť na editovanie"
-            />
-          </PreviewIconFlex>
+          <MarkdownPreview />
           <MarkdownView children={text} />
         </CommentField>
       )}
@@ -125,25 +118,32 @@ const CommentField = styled.div`
   border: 1px solid var(--color-accent);
 `
 
-const PreviewIconFlex = styled(Flex)`
+const MarkdownPreviewFlex = styled(Flex)`
+  padding-right: 12px;
   width: 100%;
+`
+
+const PreviewWrapper = styled(Flex)`
+  &:hover {
+    cursor: pointer;
+  }
 `
 
 const IconStyle = css`
   color: var(--color-accent);
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
 
   &:hover {
     cursor: pointer;
   }
 `
 
-const StyledPreviewIcon = styled(MdOutlinePreview)`
+const StyledToggleLeftIcon = styled(BiToggleLeft)`
   ${IconStyle}
 `
 
-const StyledEditIcon = styled(AiOutlineEdit)`
+const StyledToggleRightIcon = styled(BiToggleRight)`
   ${IconStyle}
 `
 

--- a/src/components/domain/post-comment/EditablePostComment.tsx
+++ b/src/components/domain/post-comment/EditablePostComment.tsx
@@ -1,8 +1,11 @@
 import React, {ChangeEvent, useState} from 'react'
-import styled from 'styled-components'
+import {AiOutlineEdit} from 'react-icons/ai'
+import {MdOutlinePreview} from 'react-icons/md'
+import styled, {css} from 'styled-components'
 import {useAuth} from '../../../AuthUserContext'
 import Button from '../../core/Button'
 import Flex from '../../core/Flex'
+import MarkdownView from '../../core/MarkdownView'
 import Text from '../../core/Text'
 import TextField from '../../core/TextField'
 import Loading from '../../Loading'
@@ -22,6 +25,7 @@ const EditablePostComment = ({
 }: EditablePostCommentProps) => {
   const {userId} = useAuth()
   const [text, setText] = useState<string>(initialText || '')
+  const [isInPreview, setIsInPreview] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
   const onTextChanged = (e: ChangeEvent<HTMLInputElement>) => {
@@ -36,14 +40,48 @@ const EditablePostComment = ({
     })
   }
 
+  const togglePreview = (): void => {
+    setIsInPreview(!isInPreview)
+  }
+
+  const containsMarkdown =
+    text.includes('`') ||
+    text.includes('#') ||
+    text.includes('[') ||
+    text.includes(']') ||
+    text.includes(`'`)
+
   return (
     <WrapperFlex direction="column" alignItems="flex-start" alignSelf="stretch">
-      <TextField
-        text={text}
-        onTextChanged={onTextChanged}
-        maxLength={750}
-        label="Sem napíš svoj komentár"
-      />
+      {!isInPreview && (
+        <TextField
+          itemBefore={
+            containsMarkdown && (
+              <PreviewIconFlex justifyContent="flex-end">
+                <StyledPreviewIcon
+                  onClick={() => togglePreview()}
+                  title="Zobraziť preview"
+                />
+              </PreviewIconFlex>
+            )
+          }
+          text={text}
+          onTextChanged={onTextChanged}
+          maxLength={750}
+          label="Sem napíš svoj komentár"
+        />
+      )}
+      {isInPreview && (
+        <CommentField>
+          <PreviewIconFlex justifyContent="flex-end">
+            <StyledEditIcon
+              onClick={() => togglePreview()}
+              title="Naspäť na editovanie"
+            />
+          </PreviewIconFlex>
+          <MarkdownView children={text} />
+        </CommentField>
+      )}
       {isLoading && <Loading />}
       {!isLoading && (
         <Flex direction="column" gap="6px">
@@ -78,6 +116,35 @@ const WrapperFlex = styled(Flex)`
 
 const SubmitButton = styled(Button)`
   margin-top: 12px;
+`
+
+const CommentField = styled.div`
+  width: 100%;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--color-accent);
+`
+
+const PreviewIconFlex = styled(Flex)`
+  width: 100%;
+`
+
+const IconStyle = css`
+  color: var(--color-accent);
+  width: 20px;
+  height: 20px;
+
+  &:hover {
+    cursor: pointer;
+  }
+`
+
+const StyledPreviewIcon = styled(MdOutlinePreview)`
+  ${IconStyle}
+`
+
+const StyledEditIcon = styled(AiOutlineEdit)`
+  ${IconStyle}
 `
 
 export default EditablePostComment

--- a/src/components/domain/post-comment/PostCommentItem.tsx
+++ b/src/components/domain/post-comment/PostCommentItem.tsx
@@ -6,6 +6,7 @@ import {PostComment} from '../../../types'
 import {formatDateTime, subtractDates} from '../../../utils'
 import {useDeletePostComment} from '../../../api/postComments'
 import Flex from '../../core/Flex'
+import MarkdownView from '../../core/MarkdownView'
 import Text from '../../core/Text'
 import Loading from '../../Loading'
 import UserAvatar from '../user/UserAvatar'
@@ -78,7 +79,7 @@ const PostCommentItem = ({postId, comment}: PostCommentItemProps) => {
                   )}
                 </CommentTimeWrapper>
               </Flex>
-              <StyledCommentText>{comment.commentText}</StyledCommentText>
+              <MarkdownView children={comment.commentText} />
             </Flex>
           </CommentField>
         )}
@@ -115,10 +116,6 @@ const CommentTimeWrapper = styled(Flex)`
     flex-direction: column;
     gap: 2px;
   }
-`
-
-const StyledCommentText = styled(Text)`
-  overflow-wrap: anywhere;
 `
 
 export default PostCommentItem


### PR DESCRIPTION
Coded on stream.

Could be made a bit nicer for sure, but IMO this is good enough for now.

I added a task to Trello for refactoring the whole comments stuff because there is a lot of duplication.


Edditing with markdown:
![image](https://user-images.githubusercontent.com/7520735/226477491-c2592fe0-cc69-4c95-bc15-6d17d79189a2.png)

Markdown preview:
![image](https://user-images.githubusercontent.com/7520735/226477526-b8e0bcf6-65df-47d1-8d86-90f920df0a9f.png)

